### PR TITLE
Zero out the default artwork margin.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,4 +3,5 @@ body {
 
   /* leave it to hide the scrollbars */
   overflow: hidden;
+  margin: 0;
 }


### PR DESCRIPTION
Add zero margin to boilerplate CSS to avoid the 8px default margin when reloading artwork.

I noticed that when using the default CSS, you get an 8px margin at the top and left side of the artwork when turning on live mode or when cycling through variations. This change adds default CSS to remove the margin.